### PR TITLE
more easily support form field schema changes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile("com.boundlessgeo.spatialconnect:spatialconnect:0.11.1") {
+    compile("com.boundlessgeo.spatialconnect:spatialconnect:0.11.3") {
       exclude module: 'support-v4'
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-spatialconnect",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "React Native library for SpatialConnect",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
this change matches https://github.com/boundlessgeo/spatialconnect-android-sdk/pull/192. we wanted a way to copy over the json without caring what fields it had. most of this is the 2 methods to convert a `JsonNode` object into a `WritableMap`