### PR TITLE
bugFix: add `long` conversion case

### DIFF
--- a/android/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/RNSpatialConnect.java
+++ b/android/src/main/java/com/boundlessgeo/spatialconnect/jsbridge/RNSpatialConnect.java
@@ -302,6 +302,8 @@ public class RNSpatialConnect extends ReactContextBaseJavaModule {
                 writableMap.putDouble(key, (Double) value);
             } else if (value instanceof Integer) {
                 writableMap.putInt(key, (Integer) value);
+            } else if (value instanceof Long) {
+                writableMap.putDouble(key, (Long) value);
             } else if (value instanceof String) {
                 writableMap.putString(key, (String) value);
             } else if (value instanceof Map) {
@@ -337,6 +339,10 @@ public class RNSpatialConnect extends ReactContextBaseJavaModule {
         } else if (firstObject instanceof Integer) {
             for (Object object : list) {
                 writableArray.pushInt((int) object);
+            }
+        } else if (firstObject instanceof Long) {
+            for (Object object : list) {
+                writableArray.pushDouble((long) object);
             }
         } else if (firstObject instanceof String) {
             for (Object object : list) {


### PR DESCRIPTION
Since we let Jackson do the de-/serialization I guess some numbers get treated as `long`s. This allows them for now, but treats them as double. The ideal solution would be to manually specify json conversions, but that's out of the scope of this issue.

MOB-65